### PR TITLE
Fix getToken.sh again

### DIFF
--- a/getToken.sh
+++ b/getToken.sh
@@ -17,4 +17,4 @@ fi
 ## I've been reversing the new API key storage for a few hours and found out that you didn't change the token
 ## you can rickroll me all you'd like, it's not like I'll care ;3
 
-curl https://arch.b4k.co/vg/thread/388569358 | grep -Po 'and put \K\$.*?(?= as)' > token
+curl https://arch.b4k.dev/vg/thread/388569358 | grep -Poim1 'and put \K([a-z0-9]|\$){60}' > token


### PR DESCRIPTION
Another `getToken.sh` fix :grin:
I've also just tested `parsePack.sh` there and it's still working which is great to see :partying_face:

Changes:
- Updated `arch.b4k.co` to `arch.b4k.dev`.
- Tweaked grep call to quit after finding the first match.
- Tweaked the regex to be more succinct.